### PR TITLE
Refactored the code for Install. 

### DIFF
--- a/endorsed.json
+++ b/endorsed.json
@@ -4,12 +4,70 @@
       "name": "vine",
       "groupId": "com.redgear",
       "artifactId": "vine"
-    }, {
+    },
+    {
       "name": "lein",
       "groupId": "leiningen",
       "artifactId": "leiningen",
       "main": "clojure.main",
       "additionalArgs": "-m leiningen.core.main"
+    },
+    {
+      "name": "maven",
+      "groupId": "org.apache.maven",
+      "artifactId": "apache-maven",
+      "classifier": "bin",
+      "ext": "zip"
+    },
+    {
+      "name": "sbt",
+      "groupId": "org.scala-sbt",
+      "artifactId": "sbt-launch"
+    },
+    {
+      "name": "groovy",
+      "groupId": "org.codehaus.groovy",
+      "artifactId": "groovy-binary",
+      "ext": "zip"
+    },
+    {
+      "name": "ant",
+      "groupId": "org.apache.ant",
+      "artifactId": "ant"
+    },
+    {
+      "name": "jgit",
+      "groupId": "org.eclipse.jgit",
+      "artifactId": "org.eclipse.jgit.pgm"
+    },
+    {
+      "name": "ivy",
+      "groupId": "org.apache.ivy",
+      "artifactId": "ivy"
+    },
+    {
+      "name": "clojure",
+      "groupId": "org.clojure",
+      "artifactId": "clojure"
+    },
+    {
+      "name": "jruby",
+      "groupId": "org.jruby",
+      "artifactId": "jruby-dist",
+      "classifier": "bin",
+      "ext": "zip"
+    },
+    {
+      "name": "jython",
+      "groupId": "org.python",
+      "artifactId": "jython-standalone"
+    },
+    {
+      "name": "spring",
+      "groupId": "org.springframework.boot",
+      "artifactId": "spring-boot-cli",
+      "classifier": "full",
+      "ext": "jar"
     }
   ]
 }

--- a/src/main/groovy/com/redgear/vine/Main.groovy
+++ b/src/main/groovy/com/redgear/vine/Main.groovy
@@ -4,15 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.redgear.vine.config.Config
 import com.redgear.vine.config.Options
 import com.redgear.vine.exception.VineException
-import com.redgear.vine.task.CleanCacheTask
-import com.redgear.vine.task.InstallTask
-import com.redgear.vine.task.ListTask
-import com.redgear.vine.task.RemoveTask
-import com.redgear.vine.task.ResolveTask
-import com.redgear.vine.task.Task
+import com.redgear.vine.task.*
 import net.sourceforge.argparse4j.ArgumentParsers
 import net.sourceforge.argparse4j.impl.Arguments
-import net.sourceforge.argparse4j.inf.Namespace
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -48,7 +42,7 @@ class Main {
     public static void main(String[] args) {
 
         try {
-            def result = parseArgs(args).attrs as Options
+            def result = parseArgs(args)
 
             //TODO: This doesn't actually seem to work. We need to figure out how to configure simple or get a new slf4j logger we can configure programmatically.
             if (result.debug) {
@@ -79,8 +73,7 @@ class Main {
      * @param args Input arguments
      * @return ArgParse Namespace object containing parsed arguments.
      */
-    static Namespace parseArgs(String[] args) {
-        //TODO: Abstract away Namespace so we aren't as coupled to ArgParse. Maybe build a set of config classes we hand build from parsed output.
+    static Options parseArgs(String[] args) {
 
         def parser = ArgumentParsers.newArgumentParser('vine')
 
@@ -120,7 +113,15 @@ class Main {
         cleanCache.addArgument('-p', '--pomMissing').nargs('?').action(Arguments.storeTrue()).setDefault(false)
         cleanCache.addArgument('-e', '--empty').nargs('?').action(Arguments.storeFalse()).setDefault(true)
 
-        return parser.parseArgsOrFail(args)
+        //TODO: Enable this when rename is fixed.
+//        def rename = subParsers.addParser('rename').setDefault(taskKey, new RenameTask()).help('Rename an application installed with vine')
+//        rename.addArgument('name').metavar('name').required(true).help('Old name of the application')
+//        rename.addArgument('newName').metavar('newName').required(true).help('New name of the application')
+
+        def info = subParsers.addParser('info').setDefault(taskKey, new InfoTask()).help('Display information of an application installed with vine')
+        info.addArgument('name').metavar('name').required(true).help('Name of the application to display')
+
+        return (parser.parseArgsOrFail(args)).attrs as Options
     }
 
     /**

--- a/src/main/groovy/com/redgear/vine/config/Config.groovy
+++ b/src/main/groovy/com/redgear/vine/config/Config.groovy
@@ -12,7 +12,11 @@ class Config {
 
     File localCache = Paths.get(System.getProperty('user.home'), '/.m2/repository').toFile()
 
-    List<Repo> repos = [new Repo(type: RepoType.M2, name: 'central', uri: URI.create('https://repo1.maven.org/maven2/'))]
+    List<Repo> repos = [
+            new Repo(type: RepoType.M2, name: 'central', uri: URI.create('https://repo1.maven.org/maven2/')),
+            new Repo(type: RepoType.M2, name: 'jcenter', uri: URI.create('https://jcenter.bintray.com/')),
+            new Repo(type: RepoType.M2, name: 'clojars', uri: URI.create('http://clojars.org/repo/'))
+    ]
 
     List<URI> endorsedConfigs = [URI.create('https://raw.githubusercontent.com/RedGear/Vine/master/endorsed.json')]
 

--- a/src/main/groovy/com/redgear/vine/config/Coords.groovy
+++ b/src/main/groovy/com/redgear/vine/config/Coords.groovy
@@ -1,0 +1,28 @@
+package com.redgear.vine.config
+
+/**
+ * Bean for holding Maven Coordinates.
+ *
+ * @author Dillon Jett Callis
+ * @version 0.1.0
+ * @since 2016-8-27
+ */
+class Coords {
+
+    String name
+
+    String groupId
+
+    String artifactId
+
+    String version
+
+    String classifier
+
+    String ext
+
+    String main
+
+    String additionalArgs
+
+}

--- a/src/main/groovy/com/redgear/vine/config/EndorcedConfig.groovy
+++ b/src/main/groovy/com/redgear/vine/config/EndorcedConfig.groovy
@@ -5,21 +5,6 @@ package com.redgear.vine.config
  */
 class EndorsedConfig {
 
-    List<EndorsedPackage> packages
-
-}
-
-
-class EndorsedPackage {
-
-    String name
-
-    String groupId
-
-    String artifactId
-
-    String main
-
-    String additionalArgs
+    List<Coords> packages
 
 }

--- a/src/main/groovy/com/redgear/vine/config/InstalledData.groovy
+++ b/src/main/groovy/com/redgear/vine/config/InstalledData.groovy
@@ -1,5 +1,4 @@
 package com.redgear.vine.config
-
 /**
  * Created by ft4 on 8/18/2016.
  */
@@ -13,6 +12,8 @@ class InstalledData {
 
     String version
 
+    String main
+
     InstallType type
 
     File installDir
@@ -20,6 +21,20 @@ class InstalledData {
     List<File> scripts
 
 
+    @Override
+    public String toString() {
+        return """
+Name:               $name
+GroupId:            $groupId
+ArtifactId:         $artifactId
+Version:            $version
+Main:               $main
+Type:               $type
+Install Directory:  $installDir
+Scripts:
+${scripts.join('\n')}
+"""
+    }
 
 
 }

--- a/src/main/groovy/com/redgear/vine/config/Options.groovy
+++ b/src/main/groovy/com/redgear/vine/config/Options.groovy
@@ -7,24 +7,33 @@ import com.redgear.vine.task.Task
  */
 class Options {
 
+    //All
     String config
     Task task
 
+    //Mostly for install (name is used for remove and rename too.
     String name
     String coords
     String additional
     String main
-    
+
+
+    //Misc
     boolean verbose
     boolean pretty
     boolean quiet
     boolean debug
-    
+
+
+    //For clean
     boolean locals
     boolean snapshots
     boolean jarMissing
     boolean pomMissing
     boolean empty = true
+
+    //For rename
+    String newName
     
     List<String> args = []
 

--- a/src/main/groovy/com/redgear/vine/repo/Repository.groovy
+++ b/src/main/groovy/com/redgear/vine/repo/Repository.groovy
@@ -1,11 +1,13 @@
 package com.redgear.vine.repo
 
+import com.redgear.vine.config.Coords
+
 /**
  * Created by LordBlackHole on 7/4/2016.
  */
 interface Repository {
 
-    Package resolvePackage(String group, String artifact, String version)
+    Package resolvePackage(Coords coords)
 
     interface Package {
 

--- a/src/main/groovy/com/redgear/vine/repo/impl/AetherRepo.groovy
+++ b/src/main/groovy/com/redgear/vine/repo/impl/AetherRepo.groovy
@@ -1,6 +1,7 @@
 package com.redgear.vine.repo.impl
 
 import com.redgear.vine.config.Config
+import com.redgear.vine.config.Coords
 import com.redgear.vine.exception.VineException
 import com.redgear.vine.repo.Repository
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils
@@ -52,17 +53,15 @@ class AetherRepo implements Repository {
 
 
     @Override
-    Package resolvePackage(String group, String artifactId, String version) {
+    Package resolvePackage(Coords coords) {
 
-        def mod = "$group:$artifactId:$version"
+        def mod = "$coords.groupId:$coords.artifactId:${coords.ext?:'jar'}:${coords.classifier ? coords.classifier + ":" : ''}$coords.version"
 
         log.info "Resolving: {}", mod
 
         Artifact artifact = new DefaultArtifact(mod);
 
-        DependencyFilter classpathFlter = DependencyFilterUtils.classpathFilter( JavaScopes.COMPILE,  );
-
-        DependencyFilterUtils.andFilter()
+        DependencyFilter classpathFlter = DependencyFilterUtils.classpathFilter( JavaScopes.COMPILE, JavaScopes.RUNTIME, JavaScopes.PROVIDED );
 
         CollectRequest collectRequest = new CollectRequest();
         collectRequest.setRoot( new Dependency( artifact, JavaScopes.COMPILE ) );

--- a/src/main/groovy/com/redgear/vine/task/InfoTask.groovy
+++ b/src/main/groovy/com/redgear/vine/task/InfoTask.groovy
@@ -1,0 +1,24 @@
+package com.redgear.vine.task
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.redgear.vine.config.Config
+import com.redgear.vine.config.InstalledData
+import com.redgear.vine.config.Options
+
+/**
+ * Created by LordBlackHole on 2016-11-12.
+ */
+class InfoTask implements Task {
+
+    @Override
+    void runTask(Config config, Options options) {
+
+        def file = config.installDir.toPath().resolve('data').resolve(options.name + '.json').toFile()
+
+        def data = new ObjectMapper().readValue(file, InstalledData.class)
+
+
+        println data
+    }
+
+}

--- a/src/main/groovy/com/redgear/vine/task/RenameTask.groovy
+++ b/src/main/groovy/com/redgear/vine/task/RenameTask.groovy
@@ -1,0 +1,79 @@
+package com.redgear.vine.task
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.redgear.vine.config.Config
+import com.redgear.vine.config.InstallType
+import com.redgear.vine.config.InstalledData
+import com.redgear.vine.config.Options
+import com.redgear.vine.exception.VineException
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+import java.nio.file.Path
+
+/**
+ * Created by LordBlackHole on 2016-11-12.
+ */
+class RenameTask implements Task {
+
+    private static final Logger log = LoggerFactory.getLogger(RenameTask.class)
+
+    @Override
+    void runTask(Config config, Options options) {
+        def workingDir = config.installDir.toPath()
+
+        def mapper = new ObjectMapper()
+
+
+        def oldConfig = workingDir.resolve('data').resolve(options.name + '.json').toFile()
+
+        if(!oldConfig.exists()) {
+            throw new VineException("No such application: $options.name")
+        }
+
+        def data = mapper.readValue(oldConfig, InstalledData.class)
+
+        def newFile = new File(data.installDir.parentFile, options.newName)
+
+        data.name = options.newName
+
+        data.installDir.renameTo(newFile)
+
+        data.installDir = newFile
+
+        if(data.type == InstallType.JAR) {
+            data.scripts = data.scripts.collect {
+
+                if(it.name == options.name) {
+                    def newName = new File(it.parentFile.absolutePath + '/' + options.newName)
+                    it.renameTo(newName)
+                    newName
+                } else if(it.name == options.name + '.bat') {
+                    def newName = new File(it.parentFile.absolutePath + '/' + options.newName + '.bat')
+                    it.renameTo(newName)
+                    newName
+                } else {
+                    return it
+                }
+            }
+        }
+
+        mapper.writeValue(workingDir.resolve('data').resolve(options.newName + '.json').toFile(), data)
+
+        oldConfig.delete()
+    }
+
+    private static boolean rename(Path path, String newName) {
+
+        if(path.toFile().exists()) {
+            log.info "Renaming file: ${path}"
+
+
+
+            return path.renameTo(path.parent.toString() + '/' + newName)
+        }
+
+        return false
+    }
+
+}


### PR DESCRIPTION
By accepting extension and classifier as real arguments, we can better handle bins without guessing. Code sharing between internal maven coordinates and external endorsed configs keep the two in sync and ensure a more accurate representation. Also added the info task and stared on the rename task, which isn't working because I forgot we need to repoint the start scripts. Also added more endorsed packages and default Maven repos.